### PR TITLE
Use Github generated release notes

### DIFF
--- a/workflow-templates/create-release.yaml
+++ b/workflow-templates/create-release.yaml
@@ -16,9 +16,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Create Release
         uses: softprops/action-gh-release@v1
-      - name: Write Release Notes
-        uses: lakto/gren-action@v2.0.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
-          options: '--override --data-source=commits'
+          generate_release_notes: true


### PR DESCRIPTION
Description of changes:
Previously we were relying on a 3rd party tool (`gren`) to generate release notes for every newly tagged release. `gren` is not well supported anymore since the release of Github's native generated release notes.

This PR removes the dependency on `gren` and instead generates the release notes using Github's native format.

Example of new release format (for `s3-controller` `v0.0.12`):
```md
## What's Changed
* Fix grants being applied for default ACLs by @RedbackThomson in https://github.com/aws-controllers-k8s/s3-controller/pull/65
* Update ACK runtime to `v0.16.5` by @ack-bot in https://github.com/aws-controllers-k8s/s3-controller/pull/67


**Full Changelog**: https://github.com/aws-controllers-k8s/s3-controller/compare/v0.0.11...v0.0.12
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
