### PR TITLE
Use Node24 supported versions for create-release

### DIFF
--- a/.github/workflows/reusable-create-release.yaml
+++ b/.github/workflows/reusable-create-release.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
Issue #, if available:

Description of changes:
GitHub will be [deprecating](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) actions using Node 20 later this year. This PR updates our create-release reusable workflow to use versions updated to use Node 24 to prevent our actions from being impacted once EOL date is reached.

- Update actions/checkout to v7
- Update softprops/action-gh-release to v3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
